### PR TITLE
Enable gcrypt to fix NodeOS/NodeOS#304

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -131,7 +131,7 @@ if [[ ! -d $STEP_DIR ]]; then
                        --audio-drv-list=$AUDIO    \
                        --disable-bzip2            \
                        --disable-docs             \
-                       --disable-gcrypt           \
+                       --enable-gcrypt            \
                        --disable-gnutls           \
                        --disable-lzo              \
                        --disable-snappy           \


### PR DESCRIPTION
This would fix the error but i was unable to start NodeOS... after i typed `npm start` it just does nothing
The compile process goes without critical errors with that, i tried that in [luii/NodeOS#gcrypt](https://github.com/luii/NodeOS/tree/gcrypt)